### PR TITLE
Modify ThreadRental to let it use UI thread.

### DIFF
--- a/src/Xunit.StaFact/Sdk/ThreadRental.cs
+++ b/src/Xunit.StaFact/Sdk/ThreadRental.cs
@@ -50,10 +50,11 @@ namespace Xunit.Sdk
         {
             var disposalTaskSource = new TaskCompletionSource<object?>();
             var syncContextSource = new TaskCompletionSource<SynchronizationContext>();
-            var threadName = $"{testMethod.TestClass.Class.Name}.{testMethod.Method.Name}";
+            // var threadName = $"{testMethod.TestClass.Class.Name}.{testMethod.Method.Name}";
+            var threadName = "MainThread";
             var thread = new Thread(() =>
             {
-                var uiSyncContext = syncContextAdapter.Create(threadName);
+                var uiSyncContext = SynchronizationContext.Current;
                 if (syncContextAdapter.ShouldSetAsCurrent)
                 {
                     SynchronizationContext.SetSynchronizationContext(uiSyncContext);


### PR DESCRIPTION
This PR is to let ThreadRental.cs use UI thread instead of creating and using a new thread. Then we can test it by generating NuGet package and use in the vsmac repo to test this feature. The overall goal is to make the UIFact using UI thread instead of manually referring to the SynchronizatonContext.Current instead.